### PR TITLE
feat: add floating back to top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,22 @@
   </div>
 </footer>
 
+    <button id="backToTop" class="back-to-top" aria-label="Back to top">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="m18 15-6-6-6 6" />
+      </svg>
+    </button>
+
     <script src="data.js"></script>
     <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ var noResults = document.getElementById('noResults');
 var searchInput = document.getElementById('searchInput');
 var filterButtons = document.querySelectorAll('.filter-btn');
 var clearBtn = document.getElementById('clearBtn');
+var backToTopBtn = document.getElementById('backToTop');
 
 // set snippet count badge
 var snippetBadge = document.getElementById('snippetBadge');
@@ -65,6 +66,32 @@ function initializeApp() {
     filterButtons.forEach(function(button) {
         button.addEventListener('click', handleFilter);
     });
+
+    // Back to Top functionality
+    if (backToTopBtn) {
+        var isVisible = false;
+
+        window.addEventListener('scroll', function() {
+            var shouldBeVisible = window.pageYOffset > 300;
+            
+            // Only update DOM if state changed
+            if (shouldBeVisible !== isVisible) {
+                isVisible = shouldBeVisible;
+                if (isVisible) {
+                    backToTopBtn.classList.add('visible');
+                } else {
+                    backToTopBtn.classList.remove('visible');
+                }
+            }
+        });
+
+        backToTopBtn.addEventListener('click', function() {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        });
+    }
 }
 
 // handle search input - filters cards by title or description

--- a/style.css
+++ b/style.css
@@ -368,3 +368,48 @@ body {
     color: var(--text-muted);
     padding-left: 4px;
 }
+
+/* 12. Back to Top Button */
+.back-to-top {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: 45px;
+    height: 45px;
+    background-color: var(--card-bg);
+    color: var(--accent-color);
+    border: 2px solid var(--accent-color);
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 10px var(--card-shadow-hover);
+    z-index: 1000;
+    opacity: 0;
+    pointer-events: none;
+    transition: all 0.3s ease;
+    transform: translateY(10px);
+}
+
+.back-to-top.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+.back-to-top:hover {
+    background-color: var(--accent-color);
+    color: white;
+    transform: translateY(-3px);
+    box-shadow: 0 6px 15px var(--card-shadow-hover);
+}
+
+@media (max-width: 768px) {
+    .back-to-top {
+        bottom: 20px;
+        right: 20px;
+        width: 40px;
+        height: 40px;
+    }
+}


### PR DESCRIPTION
## Related Issue
Closes #21
**Note:** Please add the **ACM Sourcery** label to the related issue.

---

## Description
Implements a floating **"Back to Top"** button to enhance navigation across long cheatsheet lists. The button becomes visible after a scroll threshold of **300px** and enables a smooth scrolling experience, all while maintaining **zero external dependencies**.

---

## File Changes

### `index.html`
- Added the button element with an SVG icon.
- Included appropriate `aria-label` for accessibility compliance.

### `style.css`
- Implemented fixed positioning for persistent visibility.
- Added hover states for better user interaction feedback.
- Managed `z-index` to ensure proper layering within the minimal UI.

### `script.js`
- Added scroll event listener to toggle button visibility based on position.
- Implemented smooth scroll behavior for seamless navigation to the top.

---

## Visuals

https://github.com/user-attachments/assets/fb77896e-3304-4c4f-863d-9797331442e5

---

## Conclusion
Please let me know if any changes are required. If everything looks good, I’d appreciate a merge!